### PR TITLE
Fixed Build Tooling so incremental only updates proper AssemblyInfo file close Issue #20

### DIFF
--- a/ATAP.Utilities.BuildTooling.CSharp/ATAP.Utilities.BuildTooling.targets
+++ b/ATAP.Utilities.BuildTooling.CSharp/ATAP.Utilities.BuildTooling.targets
@@ -60,13 +60,14 @@
          @(_DebugSymbolsIntermediatePath);                 
          $(NonExistentFile);
          @(CustomAdditionalCompileOutputs)">
-    <!-- increment task here -->
+    <!-- Conditionally call increment task here, if UpdatePackageVersionLockFilePath file does not exist -->
     <Message Condition="'$(ATAPBuildToolingConfiguration)'=='Debug' and !Exists('$(UpdatePackageVersionLockFilePath)')" Text="UpdatePackageVersionBeforeOuterBuild WILL execute becasue $(UpdatePackageVersionLockFilePath) DOES NOT exist" />
     <Message Condition="'$(ATAPBuildToolingConfiguration)'=='Debug' and Exists('$(UpdatePackageVersionLockFilePath)')" Text="UpdatePackageVersionBeforeOuterBuild WILL NOT execute becasue $(UpdatePackageVersionLockFilePath) DOES exist" />
     <CallTarget Targets="UpdatePackageVersionBeforeOuterBuild" Condition="!Exists('$(UpdatePackageVersionLockFilePath)')"/>
-
+  </Target>
+  
 <!-- This is the  target that updates the versioninformation during development for every build -->
-  <Target Name="UpdatePackageVersionBeforeOuterBuild" Condition="!Exists('$(UpdatePackageVersionLockFilePath)')">
+  <Target Name="UpdatePackageVersionBeforeOuterBuild" >
     <!-- during debugging this BuildTooling, send to the output log messages  indicating lockfile will be created -->
     <Message Condition="'$(ATAPBuildToolingConfiguration)'=='Debug'" Text="creating LockFile $(UpdatePackageVersionLockFilePath)" />
     <!-- Start with the creation of a lockfile to ensure version is not incrememnted in every framework when targeting multi-frameworks-->

--- a/ATAP.Utilities.BuildTooling.CSharp/Properties/AssemblyInfo.cs
+++ b/ATAP.Utilities.BuildTooling.CSharp/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 
 // ATAP.Utilities.BuildTooling.targets will update the build (date in yMMdd format), and revision fields each time a new build occurs
-[assembly:AssemblyFileVersion("1.0.6896.40469")]
+[assembly:AssemblyFileVersion("1.0.6897.34776")]
 // ATAP.Utilities.BuildTooling.targets will update the AssemblyInformationalVersion field each time a new build occurs
 [assembly:AssemblyInformationalVersion("1.0.0")]
 [assembly:AssemblyVersion("1.0.0")]


### PR DESCRIPTION
Added BeforeCompile Task and added conditional call to UpdateVersion only when lockfile does not exist