### PR TITLE
feat(database): add cross-schema user views for Issue 85

### DIFF
--- a/Database/Documentation/CrossSchema_UserView_Design.md
+++ b/Database/Documentation/CrossSchema_UserView_Design.md
@@ -1,0 +1,135 @@
+# Cross-Schema User View Design
+
+Migration: `V00.01.000303__Create_User_Views.sql`
+
+---
+
+## Purpose
+
+This migration creates three views to support consolidated display and
+cross-schema reconciliation of user data:
+
+| View | Schema | Purpose |
+|---|---|---|
+| `vw_UserFull` | `ATAPUtilities` | Full user row within ATAPUtilities |
+| `vw_UserFull` | `AceCommander` | Full user row within AceCommander |
+| `vw_UserCrossSchema` | `AceCommander` | Reconciles both schemas on `EmailHash` |
+
+---
+
+## Schema Model
+
+Both `ATAPUtilities` and `AceCommander` share an identical three-table
+user structure in the same physical database (`ATAPUtilities`):
+
+```
+[User]
+  UserId               UNIQUEIDENTIFIER   — stable app-level identity
+  EmailHash            CHAR(64)           — SHA-256 hex of normalised email
+  SaltedAndHashedPassword  NVARCHAR(500)  — Argon2id PHC string
+  HashAlgorithmName    NVARCHAR(50)
+
+[UserInformation]  (FK → User.UserId)
+  FirstName            VARBINARY(MAX)     — ciphertext
+  LastName             VARBINARY(MAX)     — ciphertext
+  Email                VARBINARY(MAX)     — ciphertext
+  Phone                VARBINARY(MAX)     — ciphertext
+  Role                 VARBINARY(MAX)     — ciphertext
+  EncryptionKeyVersion TINYINT
+
+[UserSettings]  (FK → User.UserId)
+  PreferredTheme       NVARCHAR(200)      — clear text
+  IsDarkMode           BIT                — clear text
+  Language             NVARCHAR(200)      — clear text
+```
+
+AceCommander rows are seeded from ATAPUtilities via migration
+`V00.01.000050__Populate_AceCommander_User_Tables.sql`, using freshly
+generated GUIDs for `PhiloteId`/`UserId` but preserving `EmailHash` and
+all ciphertext payloads.
+
+---
+
+## Joins
+
+### `vw_UserFull` (both schemas)
+
+```
+[User]
+  LEFT JOIN UserInformation ON UserId
+  LEFT JOIN UserSettings    ON UserId
+```
+
+LEFT JOIN ensures that a `[User]` row is always returned even when no
+`UserInformation` or `UserSettings` row has been inserted yet.
+
+### `AceCommander.vw_UserCrossSchema`
+
+```
+AceCommander.[User]                           (base — always present)
+  LEFT JOIN AceCommander.UserInformation      ON UserId
+  LEFT JOIN AceCommander.UserSettings         ON UserId
+  LEFT JOIN ATAPUtilities.[User]              ON EmailHash (non-NULL only)
+  LEFT JOIN ATAPUtilities.UserInformation     ON UserId
+  LEFT JOIN ATAPUtilities.UserSettings        ON UserId
+```
+
+AceCommander is the left/driving side so that AceCommander users without
+an ATAPUtilities counterpart still appear in the view with NULL columns
+for the ATAPUtilities side.
+
+---
+
+## Cross-Schema Join Key Choice
+
+`EmailHash` (SHA-256 hex of normalised email) was chosen as the
+reconciliation key for these reasons:
+
+- It is stable: it does not change when GUIDs are re-generated during
+  schema copy migrations.
+- It is indexed on both schemas (`IX_User_EmailHash` /
+  `AC_IX_User_EmailHash`), keeping join performance predictable.
+- It does not expose PII in query plans or slow-query logs; the raw
+  email address remains encrypted.
+
+The NULL guard (`AND ac_u.EmailHash IS NOT NULL`) prevents unintentional
+cross-row matches when a user was inserted without an email address.
+
+---
+
+## Security Posture
+
+| Layer | Mechanism |
+|---|---|
+| **Data at rest** | PII columns (`FirstName`, `LastName`, `Email`, `Phone`, `Role`) stored as `VARBINARY(MAX)` ciphertext via `ENCRYPTBYPASSPHRASE` (SQL Server Triple-DES). |
+| **Data in transit** | TLS enforced at the database connection layer. |
+| **Client display path** | Application calls `ATAPUtilities.usp_GetDecryptedUserInformation(@UserId, @Passphrase)` to obtain clear-text PII for approved display scenarios. The passphrase is loaded from the application configuration key `UserPii:PassphraseV1` (env var `UserPii__PassphraseV1`). |
+| **Non-PII settings** | `PreferredTheme`, `IsDarkMode`, and `Language` are stored as clear text and are directly readable from the views. |
+| **Views** | These views expose ciphertext columns as-is. They do not perform decryption. Decryption only occurs in the stored procedure layer, where the caller supplies the passphrase. |
+
+### Key rotation
+
+`EncryptionKeyVersion` tracks which passphrase version encrypted each
+row. Zero-downtime rotation re-encrypts rows incrementally and bumps the
+version field.
+
+---
+
+## Trade-offs and Alternatives Considered
+
+| Decision | Rationale |
+|---|---|
+| Views expose ciphertext rather than decrypting inline | SQL `VIEW` objects cannot accept parameters; `DECRYPTBYPASSPHRASE` requires a runtime passphrase. Inline decryption would require a schema-bound passphrase constant, which is a security anti-pattern. |
+| AceCommander as the driving side for `vw_UserCrossSchema` | AceCommander is the consumer schema; showing AC rows first matches the display use case. ATAPUtilities side is optionally joined. |
+| LEFT JOIN for all child tables | Guarantees no user is silently dropped from the view when child rows are missing (e.g., new users before settings are configured). |
+| `EmailHash` as join key instead of direct UserId mapping | UserId namespaces differ by design (see `V00.01.000050`). EmailHash is the only durable, cross-schema stable identifier. |
+
+---
+
+## Migration Replacement / Forward-Fix Guidance
+
+Because views are created with `CREATE OR ALTER VIEW` (wrapped in a
+drop-then-create pattern for Flyway idempotency), a forward-fix that
+changes the view definition should be applied as a new versioned migration
+(e.g., `V00.01.000304__...`) that re-creates the views rather than
+modifying this file. This preserves the Flyway checksum chain.

--- a/Database/Flyway/Data/User_UserInformation.csv
+++ b/Database/Flyway/Data/User_UserInformation.csv
@@ -1,2 +1,2 @@
 "UserId","FirstName","LastName","Email","Phone","Role"
-"5d2e8f3c-1a7b-4c9d-b4e5-6f7a8b9c0d1e","","Guest","","+17046340019",""
+"5d2e8f3c-1a7b-4c9d-b4e5-6f7a8b9c0d1e","Guest","Guest","","+17046340019",""

--- a/Database/Flyway/SQL/V00.01.000303__Create_User_Views.sql
+++ b/Database/Flyway/SQL/V00.01.000303__Create_User_Views.sql
@@ -1,0 +1,151 @@
+USE ATAPUtilities;
+GO
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+/* ============================================================
+   V00.01.000303 — Create User Views (cross-schema)
+
+   Creates three views for user display and reconciliation:
+
+     1. ATAPUtilities.vw_UserFull
+        Full user row with LEFT JOINs to UserInformation and
+        UserSettings within the ATAPUtilities schema.
+
+     2. AceCommander.vw_UserFull
+        Mirrors ATAPUtilities.vw_UserFull within AceCommander.
+
+     3. AceCommander.vw_UserCrossSchema
+        Joins AceCommander and ATAPUtilities user rows on the
+        stable cross-schema key (EmailHash) to support
+        reconciliation and combined display pages.
+
+   Security posture:
+     - Data at rest: PII columns (FirstName, LastName, Email,
+       Phone, Role) are stored as VARBINARY ciphertext encrypted
+       with ENCRYPTBYPASSPHRASE.  Views expose ciphertext as-is.
+     - Data in transit: TLS enforced at the connection layer.
+     - Clear-text display: callers decrypt via
+       ATAPUtilities.usp_GetDecryptedUserInformation, supplying
+       the passphrase from the application configuration.
+       Non-PII settings columns (PreferredTheme, IsDarkMode,
+       Language) are already clear text.
+
+   LEFT JOIN rationale:
+     All child joins (UserInformation, UserSettings) use LEFT JOIN
+     so that base [User] rows are preserved even when related rows
+     do not yet exist.  The cross-schema join also uses LEFT JOIN
+     so that AceCommander users without a matching ATAPUtilities
+     counterpart are still visible in vw_UserCrossSchema.
+   ============================================================ */
+
+-- ============================================================
+-- 1. ATAPUtilities.vw_UserFull
+-- ============================================================
+IF OBJECT_ID(N'ATAPUtilities.vw_UserFull', N'V') IS NOT NULL
+    DROP VIEW ATAPUtilities.vw_UserFull;
+GO
+
+CREATE VIEW ATAPUtilities.vw_UserFull AS
+SELECT
+    u.UserId,
+    u.EmailHash,
+    u.HashAlgorithmName,
+    -- PII stored as ciphertext; decrypt via ATAPUtilities.usp_GetDecryptedUserInformation
+    ui.FirstName,
+    ui.LastName,
+    ui.Email,
+    ui.Phone,
+    ui.Role,
+    ui.EncryptionKeyVersion,
+    -- Settings are clear text
+    us.PreferredTheme,
+    us.IsDarkMode,
+    us.Language
+FROM ATAPUtilities.[User]            AS u
+LEFT JOIN ATAPUtilities.UserInformation AS ui ON ui.UserId = u.UserId
+LEFT JOIN ATAPUtilities.UserSettings    AS us ON us.UserId = u.UserId;
+GO
+
+-- ============================================================
+-- 2. AceCommander.vw_UserFull
+-- ============================================================
+IF OBJECT_ID(N'AceCommander.vw_UserFull', N'V') IS NOT NULL
+    DROP VIEW AceCommander.vw_UserFull;
+GO
+
+CREATE VIEW AceCommander.vw_UserFull AS
+SELECT
+    u.UserId,
+    u.EmailHash,
+    u.HashAlgorithmName,
+    -- PII stored as ciphertext; same passphrase as ATAPUtilities (copied in V00.01.000050)
+    ui.FirstName,
+    ui.LastName,
+    ui.Email,
+    ui.Phone,
+    ui.Role,
+    ui.EncryptionKeyVersion,
+    -- Settings are clear text
+    us.PreferredTheme,
+    us.IsDarkMode,
+    us.Language
+FROM AceCommander.[User]            AS u
+LEFT JOIN AceCommander.UserInformation AS ui ON ui.UserId = u.UserId
+LEFT JOIN AceCommander.UserSettings    AS us ON us.UserId = u.UserId;
+GO
+
+-- ============================================================
+-- 3. AceCommander.vw_UserCrossSchema
+--    Base: AceCommander users; joined to ATAPUtilities users
+--    using EmailHash as the stable cross-schema reconciliation key.
+--    EmailHash NULLs are excluded from the join to avoid
+--    incorrect cross-row matches.
+-- ============================================================
+IF OBJECT_ID(N'AceCommander.vw_UserCrossSchema', N'V') IS NOT NULL
+    DROP VIEW AceCommander.vw_UserCrossSchema;
+GO
+
+CREATE VIEW AceCommander.vw_UserCrossSchema AS
+SELECT
+    -- Reconciliation key
+    ac_u.EmailHash,
+
+    -- AceCommander identity
+    ac_u.UserId                  AS AC_UserId,
+    ac_u.HashAlgorithmName       AS AC_HashAlgorithmName,
+    -- AceCommander PII (ciphertext)
+    ac_ui.FirstName              AS AC_FirstName,
+    ac_ui.LastName               AS AC_LastName,
+    ac_ui.Email                  AS AC_Email,
+    ac_ui.Phone                  AS AC_Phone,
+    ac_ui.Role                   AS AC_Role,
+    ac_ui.EncryptionKeyVersion   AS AC_EncryptionKeyVersion,
+    -- AceCommander settings (clear text)
+    ac_us.PreferredTheme         AS AC_PreferredTheme,
+    ac_us.IsDarkMode             AS AC_IsDarkMode,
+    ac_us.Language               AS AC_Language,
+
+    -- ATAPUtilities identity (NULL when no match)
+    atu_u.UserId                 AS ATU_UserId,
+    atu_u.HashAlgorithmName      AS ATU_HashAlgorithmName,
+    -- ATAPUtilities PII (ciphertext)
+    atu_ui.FirstName             AS ATU_FirstName,
+    atu_ui.LastName              AS ATU_LastName,
+    atu_ui.Email                 AS ATU_Email,
+    atu_ui.Phone                 AS ATU_Phone,
+    atu_ui.Role                  AS ATU_Role,
+    atu_ui.EncryptionKeyVersion  AS ATU_EncryptionKeyVersion,
+    -- ATAPUtilities settings (clear text)
+    atu_us.PreferredTheme        AS ATU_PreferredTheme,
+    atu_us.IsDarkMode            AS ATU_IsDarkMode,
+    atu_us.Language              AS ATU_Language
+FROM AceCommander.[User]               AS ac_u
+LEFT JOIN AceCommander.UserInformation AS ac_ui  ON ac_ui.UserId  = ac_u.UserId
+LEFT JOIN AceCommander.UserSettings    AS ac_us  ON ac_us.UserId  = ac_u.UserId
+LEFT JOIN ATAPUtilities.[User]         AS atu_u  ON atu_u.EmailHash = ac_u.EmailHash
+                                                AND ac_u.EmailHash IS NOT NULL
+LEFT JOIN ATAPUtilities.UserInformation AS atu_ui ON atu_ui.UserId = atu_u.UserId
+LEFT JOIN ATAPUtilities.UserSettings    AS atu_us ON atu_us.UserId = atu_u.UserId;
+GO

--- a/Database/Powershell/tests/UserViews.Tests.ps1
+++ b/Database/Powershell/tests/UserViews.Tests.ps1
@@ -1,0 +1,205 @@
+# AI assisted using pesterTest.instructions.md as guidelines
+
+$SqlInstance = if ($env:ATAPUTILITIES_SQLINSTANCE) { $env:ATAPUTILITIES_SQLINSTANCE } else { 'localhost' }
+$DatabaseName = 'ATAPUtilities'
+
+Describe 'User view existence and structure' {
+  BeforeAll {
+    if (-not (Get-Module -ListAvailable -Name dbatools)) {
+      throw 'dbatools module is required for this test. Install-Module dbatools -Scope CurrentUser'
+    }
+
+    Import-Module dbatools -ErrorAction Stop
+
+    Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig | Out-Null
+    Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig | Out-Null
+  }
+
+  It 'ATAPUtilities.vw_UserFull exists' {
+    $count = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query @'
+SELECT COUNT(*)
+FROM sys.views v
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'ATAPUtilities' AND v.name = N'vw_UserFull';
+'@)
+    $count | Should -Be 1
+  }
+
+  It 'AceCommander.vw_UserFull exists' {
+    $count = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query @'
+SELECT COUNT(*)
+FROM sys.views v
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'AceCommander' AND v.name = N'vw_UserFull';
+'@)
+    $count | Should -Be 1
+  }
+
+  It 'AceCommander.vw_UserCrossSchema exists' {
+    $count = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query @'
+SELECT COUNT(*)
+FROM sys.views v
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'AceCommander' AND v.name = N'vw_UserCrossSchema';
+'@)
+    $count | Should -Be 1
+  }
+
+  It 'ATAPUtilities.vw_UserFull contains expected columns' {
+    $expectedColumns = @('UserId', 'EmailHash', 'HashAlgorithmName', 'FirstName', 'LastName', 'Email', 'Phone', 'Role', 'EncryptionKeyVersion', 'PreferredTheme', 'IsDarkMode', 'Language')
+
+    $actualColumns = @(Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As PSObject -EnableException -ErrorAction Stop -Query @'
+SELECT c.name AS ColumnName
+FROM sys.columns c
+INNER JOIN sys.views v ON v.object_id = c.object_id
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'ATAPUtilities' AND v.name = N'vw_UserFull'
+ORDER BY c.column_id;
+'@ | Select-Object -ExpandProperty ColumnName)
+
+    foreach ($col in $expectedColumns) {
+      $actualColumns | Should -Contain $col
+    }
+  }
+
+  It 'AceCommander.vw_UserFull contains expected columns' {
+    $expectedColumns = @('UserId', 'EmailHash', 'HashAlgorithmName', 'FirstName', 'LastName', 'Email', 'Phone', 'Role', 'EncryptionKeyVersion', 'PreferredTheme', 'IsDarkMode', 'Language')
+
+    $actualColumns = @(Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As PSObject -EnableException -ErrorAction Stop -Query @'
+SELECT c.name AS ColumnName
+FROM sys.columns c
+INNER JOIN sys.views v ON v.object_id = c.object_id
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'AceCommander' AND v.name = N'vw_UserFull'
+ORDER BY c.column_id;
+'@ | Select-Object -ExpandProperty ColumnName)
+
+    foreach ($col in $expectedColumns) {
+      $actualColumns | Should -Contain $col
+    }
+  }
+
+  It 'AceCommander.vw_UserCrossSchema contains expected columns' {
+    $expectedColumns = @(
+      'EmailHash',
+      'AC_UserId', 'AC_HashAlgorithmName', 'AC_FirstName', 'AC_LastName', 'AC_Email', 'AC_Phone', 'AC_Role', 'AC_EncryptionKeyVersion', 'AC_PreferredTheme', 'AC_IsDarkMode', 'AC_Language',
+      'ATU_UserId', 'ATU_HashAlgorithmName', 'ATU_FirstName', 'ATU_LastName', 'ATU_Email', 'ATU_Phone', 'ATU_Role', 'ATU_EncryptionKeyVersion', 'ATU_PreferredTheme', 'ATU_IsDarkMode', 'ATU_Language'
+    )
+
+    $actualColumns = @(Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As PSObject -EnableException -ErrorAction Stop -Query @'
+SELECT c.name AS ColumnName
+FROM sys.columns c
+INNER JOIN sys.views v ON v.object_id = c.object_id
+INNER JOIN sys.schemas s ON s.schema_id = v.schema_id
+WHERE s.name = N'AceCommander' AND v.name = N'vw_UserCrossSchema'
+ORDER BY c.column_id;
+'@ | Select-Object -ExpandProperty ColumnName)
+
+    foreach ($col in $expectedColumns) {
+      $actualColumns | Should -Contain $col
+    }
+  }
+}
+
+Describe 'User view query behavior' {
+  BeforeAll {
+    if (-not (Get-Module -ListAvailable -Name dbatools)) {
+      throw 'dbatools module is required for this test. Install-Module dbatools -Scope CurrentUser'
+    }
+
+    Import-Module dbatools -ErrorAction Stop
+
+    Set-DbatoolsConfig -FullName sql.connection.trustcert -Value $true -PassThru | Register-DbatoolsConfig | Out-Null
+    Set-DbatoolsConfig -FullName sql.connection.encrypt -Value $false -PassThru | Register-DbatoolsConfig | Out-Null
+  }
+
+  It 'ATAPUtilities.vw_UserFull is queryable and returns rows when users exist' {
+    $userCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query 'SELECT COUNT(*) FROM ATAPUtilities.[User];')
+
+    if ($userCount -eq 0) {
+      Set-ItResult -Skipped -Because 'No ATAPUtilities users present; run user data migrations first.'
+      return
+    }
+
+    $viewCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query 'SELECT COUNT(*) FROM ATAPUtilities.vw_UserFull;')
+    $viewCount | Should -Be $userCount
+  }
+
+  It 'AceCommander.vw_UserFull is queryable and returns rows when users exist' {
+    $userCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query 'SELECT COUNT(*) FROM AceCommander.[User];')
+
+    if ($userCount -eq 0) {
+      Set-ItResult -Skipped -Because 'No AceCommander users present; run user data migrations first.'
+      return
+    }
+
+    $viewCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query 'SELECT COUNT(*) FROM AceCommander.vw_UserFull;')
+    $viewCount | Should -Be $userCount
+  }
+
+  It 'ATAPUtilities.vw_UserFull LEFT JOIN preserves User rows when UserInformation is absent' {
+    # Insert an isolated user with no UserInformation or UserSettings row,
+    # verify the view returns the row with NULL PII columns, then clean up.
+    $testPhiloteId = [guid]::NewGuid().ToString()
+    $testUserId = [guid]::NewGuid().ToString()
+
+    Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -EnableException -ErrorAction Stop -Query @"
+INSERT INTO ATAPUtilities.Philote (PhiloteId) VALUES ('$testPhiloteId');
+INSERT INTO ATAPUtilities.[User]  (PhiloteId, UserId, HashAlgorithmName) VALUES ('$testPhiloteId', '$testUserId', N'Argon2id');
+"@
+
+    try {
+      $row = Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As PSObject -EnableException -ErrorAction Stop -Query @"
+SELECT UserId, FirstName, PreferredTheme
+FROM ATAPUtilities.vw_UserFull
+WHERE UserId = '$testUserId';
+"@
+
+      $row | Should -Not -BeNullOrEmpty
+      $row.FirstName      | Should -BeNullOrEmpty
+      $row.PreferredTheme | Should -BeNullOrEmpty
+    }
+    finally {
+      Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -EnableException -ErrorAction Stop -Query @"
+DELETE FROM ATAPUtilities.[User]   WHERE UserId   = '$testUserId';
+DELETE FROM ATAPUtilities.Philote  WHERE PhiloteId = '$testPhiloteId';
+"@
+    }
+  }
+
+  It 'AceCommander.vw_UserCrossSchema cross-schema join returns matched rows when EmailHash aligns' {
+    $acUserCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query "SELECT COUNT(*) FROM AceCommander.[User] WHERE EmailHash IS NOT NULL;")
+    $atuUserCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query "SELECT COUNT(*) FROM ATAPUtilities.[User] WHERE EmailHash IS NOT NULL;")
+
+    if ($acUserCount -eq 0 -or $atuUserCount -eq 0) {
+      Set-ItResult -Skipped -Because "Cross-schema join test requires users with EmailHash in both schemas (AC=$acUserCount, ATU=$atuUserCount)."
+      return
+    }
+
+    $matchedCount = [int](Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As SingleValue -EnableException -ErrorAction Stop -Query @'
+SELECT COUNT(*)
+FROM AceCommander.vw_UserCrossSchema
+WHERE ATU_UserId IS NOT NULL;
+'@)
+    $matchedCount | Should -BeGreaterThan 0
+  }
+
+  It 'AceCommander.vw_UserCrossSchema settings columns are clear text (not VARBINARY) for matched rows' {
+    $sampleRow = Invoke-DbaQuery -SqlInstance $SqlInstance -Database $DatabaseName -As PSObject -EnableException -ErrorAction Stop -Query @'
+SELECT TOP (1)
+    AC_IsDarkMode,
+    ATU_IsDarkMode
+FROM AceCommander.vw_UserCrossSchema
+WHERE ATU_UserId IS NOT NULL;
+'@
+
+    if (-not $sampleRow) {
+      Set-ItResult -Skipped -Because 'No matched cross-schema rows available to verify clear-text settings columns.'
+      return
+    }
+
+    # IsDarkMode is BIT — confirm it is not a byte array (i.e., not encrypted VARBINARY)
+    $sampleRow.AC_IsDarkMode  | Should -BeOfType [bool]
+    $sampleRow.ATU_IsDarkMode | Should -BeOfType [bool]
+  }
+}


### PR DESCRIPTION
## Summary

Creates three Flyway-managed views (`ATAPUtilities.vw_UserFull`, `AceCommander.vw_UserFull`, `AceCommander.vw_UserCrossSchema`) that support consolidated user display and cross-schema reconciliation. Both schemas live in the same `ATAPUtilities` database, so views use schema-qualified names and join on `EmailHash` as the stable cross-schema key.

## Changes

- **`V00.01.000303__Create_User_Views.sql`** — migration creating the three views with LEFT JOINs to preserve base user rows when child rows are absent; NULL guard on `EmailHash` prevents spurious cross-schema matches
- **`CrossSchema_UserView_Design.md`** — design doc covering schema model, join rationale, key choice, security posture (encrypted at rest, encrypted in transit, clear text on approved client display path), trade-offs, and forward-fix migration guidance
- **`UserViews.Tests.ps1`** — Pester tests covering view existence, expected column structure, LEFT JOIN behaviour with isolated users, cross-schema join correctness, and clear-text settings column validation
- **`User_UserInformation.csv`** — fix blank `FirstName` seed value for the guest user row

## Testing

- Tests are in `Database/Powershell/tests/UserViews.Tests.ps1` and run via `Invoke-Pester`
- Tests skip gracefully when no user data is present; existence and structure tests require only the migration to have been applied
- LEFT JOIN test inserts and cleans up an isolated user row to verify null-preservation behaviour

## Notes

Views expose PII columns as ciphertext (`VARBINARY`). Decryption for display requires calling `ATAPUtilities.usp_GetDecryptedUserInformation(@UserId, @Passphrase)` with the application-layer passphrase. Non-PII settings columns (`PreferredTheme`, `IsDarkMode`, `Language`) are clear text directly from the views.

Closes #85