### PR TITLE
fix(ai-rendering): resolve stable settings placeholders

### DIFF
--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/ReleaseNotes.md
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/ReleaseNotes.md
@@ -12,8 +12,9 @@
 
 ## 0.1.2
 
-- Render Claude Code user-global settings from the concrete SharedVSCode
-  projection and reject unresolved stable/sprint worktree placeholders.
+- Resolve stable/sprint worktree placeholders in the full Claude Code
+  user-global overlay, omit sprint entries at the End boundary, and reject any
+  unresolved worktree token before writing user settings.
 
 ## 0.1.0
 

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/ReleaseNotes.md
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/ReleaseNotes.md
@@ -10,6 +10,11 @@
   compose unchanged. This replaces the direct manifest render that clobbered the
   composed carrier on 2026-07-25.
 
+## 0.1.2
+
+- Render Claude Code user-global settings from the concrete SharedVSCode
+  projection and reject unresolved stable/sprint worktree placeholders.
+
 ## 0.1.0
 
 - Initial AiRendering extraction from the compatibility parent.

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/public/Set-ClaudeSettingsSymlink.ps1
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/public/Set-ClaudeSettingsSymlink.ps1
@@ -1,20 +1,21 @@
 function Set-ClaudeSettingsSymlink {
   <#
   .SYNOPSIS
-    Renders the Claude Code user settings file from the concrete SharedVSCode projection.
+    Renders the Claude Code user settings file from the SharedVSCode overlay.
   .DESCRIPTION
     Retains the historical function name for sprint-boundary callers, but no
     longer creates a symlink. The cmdlet writes a real
-    ~/.claude/settings.json file from the already-rendered
-    .claude/settings.json projection, preserving unmanaged local root keys
-    already present in the target. Consuming the rendered projection keeps
-    placeholder resolution owned by Render-AIAdapters and prevents raw
-    STABLE/SPRINT_WORKTREE_PATH tokens from reaching user-global settings.
-    Existing target bytes are backed up before mutation and restored if a later
-    write step fails.
+    ~/.claude/settings.json file from
+    .ai/config/claudecode/settings.overlay.json, resolving stable and sprint
+    worktree placeholders before preserving unmanaged local root keys already
+    present in the target. Existing target bytes are backed up before mutation
+    and restored if a later write step fails.
   .PARAMETER SharedVSCodeWorktreePath
-    Path to the SharedVSCode worktree containing the concrete Claude Code
-    projection under .claude/settings.json.
+    Path to the SharedVSCode worktree containing the canonical Claude Code
+    overlay under .ai/config/claudecode/settings.overlay.json.
+  .PARAMETER OmitSprintWorktrees
+    Omits standalone sprint-worktree entries and resolves the Claude hook to
+    stable SharedVSCode. Use at the End boundary.
   .PARAMETER AllowUserGlobalWrite
     Required for live mutation of ~/.claude/settings.json.
   .PARAMETER CheckpointConfirmed
@@ -35,6 +36,8 @@ function Set-ClaudeSettingsSymlink {
     [switch]$AllowUserGlobalWrite,
 
     [switch]$CheckpointConfirmed,
+
+    [switch]$OmitSprintWorktrees,
 
     [string]$UserProfilePath = $env:USERPROFILE,
 
@@ -74,6 +77,69 @@ function Set-ClaudeSettingsSymlink {
       }
       return $InputObject
     }
+
+    function Get-LocalWorktreePathForToken {
+      param([string]$Token, [string]$WorktreeRootFull, [string]$GhRoot, [switch]$OmitSprintWorktrees)
+
+      if ($Token -notmatch '^\$\{(SPRINT|STABLE)_WORKTREE_PATH_([A-Z_]+)\}$') { return $null }
+      $kind = $Matches[1]
+      $repoKey = $Matches[2]
+      $repoFolders = @{
+        SHAREDVSCODE = 'SharedVSCode'; ATAP_PLANNING = '_Planning';
+        ATAP_UTILITIES = 'ATAP.Utilities'; ATAP_IAC = 'ATAP.IAC'; ACECOMMANDER = 'AceCommander'
+      }
+      if (-not $repoFolders.ContainsKey($repoKey)) { return $null }
+      $folder = $repoFolders[$repoKey]
+      if ($kind -eq 'STABLE') {
+        $stablePath = Join-Path $GhRoot $folder
+        if (Test-Path -LiteralPath $stablePath -PathType Container) { return [IO.Path]::GetFullPath($stablePath) }
+        return $null
+      }
+      if ($OmitSprintWorktrees) { return $null }
+      $sprintPattern = '^' + [regex]::Escape($folder) + '-wt-\d+-Sprint-\d{4}-work-items$'
+      if ((Split-Path $WorktreeRootFull -Leaf) -match $sprintPattern) { return $WorktreeRootFull }
+      $newest = Get-ChildItem -LiteralPath $GhRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match $sprintPattern } |
+        Sort-Object Name -Descending |
+        Select-Object -First 1
+      if ($newest) { return [IO.Path]::GetFullPath($newest.FullName) }
+      if ($repoKey -eq 'SHAREDVSCODE') { return $WorktreeRootFull }
+      return $null
+    }
+
+    function Resolve-LocalWorktreePlaceholderNode {
+      param([AllowNull()]$Node, [string]$WorktreeRootFull, [string]$GhRoot, [switch]$OmitSprintWorktrees)
+
+      if ($null -eq $Node) { return $null }
+      if ($Node -is [string]) {
+        $result = $Node
+        foreach ($match in [regex]::Matches($Node, '\$\{(?:SPRINT|STABLE)_WORKTREE_PATH_[A-Z_]+\}')) {
+          $token = $match.Value
+          $resolved = if ($OmitSprintWorktrees -and $Node -match 'PreToolUse-PwshGuard\.ps1' -and $token -eq '${SPRINT_WORKTREE_PATH_SHAREDVSCODE}') {
+            Get-LocalWorktreePathForToken -Token '${STABLE_WORKTREE_PATH_SHAREDVSCODE}' -WorktreeRootFull $WorktreeRootFull -GhRoot $GhRoot
+          } else {
+            Get-LocalWorktreePathForToken -Token $token -WorktreeRootFull $WorktreeRootFull -GhRoot $GhRoot -OmitSprintWorktrees:$OmitSprintWorktrees
+          }
+          if ($null -ne $resolved) { $result = $result.Replace($token, $resolved) }
+        }
+        return $result
+      }
+      if ($Node -is [System.Collections.IDictionary]) {
+        foreach ($key in @($Node.Keys)) {
+          $Node[$key] = Resolve-LocalWorktreePlaceholderNode -Node $Node[$key] -WorktreeRootFull $WorktreeRootFull -GhRoot $GhRoot -OmitSprintWorktrees:$OmitSprintWorktrees
+        }
+        return $Node
+      }
+      if ($Node -is [System.Collections.IEnumerable]) {
+        $items = [System.Collections.Generic.List[object]]::new()
+        foreach ($element in $Node) {
+          if ($element -is [string] -and $element -match '^\$\{SPRINT_WORKTREE_PATH_[A-Z_]+\}$' -and $OmitSprintWorktrees) { continue }
+          $items.Add((Resolve-LocalWorktreePlaceholderNode -Node $element -WorktreeRootFull $WorktreeRootFull -GhRoot $GhRoot -OmitSprintWorktrees:$OmitSprintWorktrees))
+        }
+        return , $items.ToArray()
+      }
+      return $Node
+    }
   }
 
   process {
@@ -90,25 +156,31 @@ function Set-ClaudeSettingsSymlink {
       }
     }
 
-    $sourceSettingsPath = Join-Path $SharedVSCodeWorktreePath '.claude\settings.json'
+    if (-not $PSBoundParameters.ContainsKey('OmitSprintWorktrees')) {
+      $OmitSprintWorktrees = (Split-Path ([IO.Path]::GetFullPath($SharedVSCodeWorktreePath)) -Leaf) -ieq 'SharedVSCode'
+    }
+
+    $overlayPath = Join-Path $SharedVSCodeWorktreePath '.ai\config\claudecode\settings.overlay.json'
     $preservePath = Join-Path $SharedVSCodeWorktreePath '.ai\config\claudecode\local-preserve.json'
     $targetPath = Join-Path `
       -Path $UserProfilePath `
       -ChildPath '.claude' `
       -AdditionalChildPath 'settings.json'
 
-    if (-not (Test-Path -LiteralPath $sourceSettingsPath -PathType Leaf)) {
-      throw "Rendered Claude Code settings projection not found at $sourceSettingsPath"
+    if (-not (Test-Path -LiteralPath $overlayPath -PathType Leaf)) {
+      throw "Claude Code settings overlay not found at $overlayPath"
     }
 
-    $sourceSettings = Get-Content -LiteralPath $sourceSettingsPath -Raw |
+    $overlay = Get-Content -LiteralPath $overlayPath -Raw |
       ConvertFrom-Json -Depth 100 -ErrorAction Stop
-    $candidate = ConvertTo-LocalHashtable -InputObject $sourceSettings
+    $candidate = ConvertTo-LocalHashtable -InputObject $overlay
+    $worktreeRootFull = [IO.Path]::GetFullPath($SharedVSCodeWorktreePath)
+    $candidate = Resolve-LocalWorktreePlaceholderNode -Node $candidate -WorktreeRootFull $worktreeRootFull `
+      -GhRoot (Split-Path $worktreeRootFull -Parent) -OmitSprintWorktrees:$OmitSprintWorktrees
 
     $unresolvedPlaceholderPattern = '\$\{(?:STABLE|SPRINT)_WORKTREE_PATH_[A-Z_]+\}'
-    $sourceSettingsText = Get-Content -LiteralPath $sourceSettingsPath -Raw
-    if ($sourceSettingsText -match $unresolvedPlaceholderPattern) {
-      throw "Rendered Claude Code settings projection contains unresolved worktree placeholders: $sourceSettingsPath"
+    if (($candidate | ConvertTo-Json -Depth 100) -match $unresolvedPlaceholderPattern) {
+      throw "Claude Code settings overlay contains unresolved worktree placeholders after resolution: $overlayPath"
     }
 
     $existingSettings = $null
@@ -164,11 +236,10 @@ function Set-ClaudeSettingsSymlink {
       $BackupRoot = Join-Path $SharedVSCodeWorktreePath '_generated\ClaudeSettingsBackups'
     }
 
-    if (-not $PSCmdlet.ShouldProcess($targetPath, 'render real Claude Code settings file from SharedVSCode projection')) {
+    if (-not $PSCmdlet.ShouldProcess($targetPath, 'render real Claude Code settings file from SharedVSCode overlay')) {
       return [PSCustomObject]@{
         TargetPath = $targetPath
-        SourceSettingsPath = $sourceSettingsPath
-        OverlayPath = $sourceSettingsPath
+        OverlayPath = $overlayPath
         BackupPath = $null
         Action = 'whatif'
         LinkType = if ($existingItem) { [string]$existingItem.LinkType } else { $null }
@@ -204,8 +275,7 @@ function Set-ClaudeSettingsSymlink {
 
       return [PSCustomObject]@{
         TargetPath = $targetPath
-        SourceSettingsPath = $sourceSettingsPath
-        OverlayPath = $sourceSettingsPath
+        OverlayPath = $overlayPath
         PreservePath = if (Test-Path -LiteralPath $preservePath -PathType Leaf) { $preservePath } else { $null }
         BackupPath = $backupPath
         Action = 'rendered'

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/public/Set-ClaudeSettingsSymlink.ps1
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/public/Set-ClaudeSettingsSymlink.ps1
@@ -1,17 +1,20 @@
 function Set-ClaudeSettingsSymlink {
   <#
   .SYNOPSIS
-    Renders the Claude Code user settings file from the SharedVSCode overlay.
+    Renders the Claude Code user settings file from the concrete SharedVSCode projection.
   .DESCRIPTION
     Retains the historical function name for sprint-boundary callers, but no
     longer creates a symlink. The cmdlet writes a real
-    ~/.claude/settings.json file from
-    .ai/config/claudecode/settings.overlay.json, preserving unmanaged local
-    root keys already present in the target. Existing target bytes are backed up
-    before mutation and restored if a later write step fails.
+    ~/.claude/settings.json file from the already-rendered
+    .claude/settings.json projection, preserving unmanaged local root keys
+    already present in the target. Consuming the rendered projection keeps
+    placeholder resolution owned by Render-AIAdapters and prevents raw
+    STABLE/SPRINT_WORKTREE_PATH tokens from reaching user-global settings.
+    Existing target bytes are backed up before mutation and restored if a later
+    write step fails.
   .PARAMETER SharedVSCodeWorktreePath
-    Path to the SharedVSCode worktree containing the canonical Claude Code
-    overlay under .ai/config/claudecode/settings.overlay.json.
+    Path to the SharedVSCode worktree containing the concrete Claude Code
+    projection under .claude/settings.json.
   .PARAMETER AllowUserGlobalWrite
     Required for live mutation of ~/.claude/settings.json.
   .PARAMETER CheckpointConfirmed
@@ -87,20 +90,26 @@ function Set-ClaudeSettingsSymlink {
       }
     }
 
-    $overlayPath = Join-Path $SharedVSCodeWorktreePath '.ai\config\claudecode\settings.overlay.json'
+    $sourceSettingsPath = Join-Path $SharedVSCodeWorktreePath '.claude\settings.json'
     $preservePath = Join-Path $SharedVSCodeWorktreePath '.ai\config\claudecode\local-preserve.json'
     $targetPath = Join-Path `
       -Path $UserProfilePath `
       -ChildPath '.claude' `
       -AdditionalChildPath 'settings.json'
 
-    if (-not (Test-Path -LiteralPath $overlayPath -PathType Leaf)) {
-      throw "Claude Code settings overlay not found at $overlayPath"
+    if (-not (Test-Path -LiteralPath $sourceSettingsPath -PathType Leaf)) {
+      throw "Rendered Claude Code settings projection not found at $sourceSettingsPath"
     }
 
-    $overlay = Get-Content -LiteralPath $overlayPath -Raw |
+    $sourceSettings = Get-Content -LiteralPath $sourceSettingsPath -Raw |
       ConvertFrom-Json -Depth 100 -ErrorAction Stop
-    $candidate = ConvertTo-LocalHashtable -InputObject $overlay
+    $candidate = ConvertTo-LocalHashtable -InputObject $sourceSettings
+
+    $unresolvedPlaceholderPattern = '\$\{(?:STABLE|SPRINT)_WORKTREE_PATH_[A-Z_]+\}'
+    $sourceSettingsText = Get-Content -LiteralPath $sourceSettingsPath -Raw
+    if ($sourceSettingsText -match $unresolvedPlaceholderPattern) {
+      throw "Rendered Claude Code settings projection contains unresolved worktree placeholders: $sourceSettingsPath"
+    }
 
     $existingSettings = $null
     if (Test-Path -LiteralPath $targetPath -PathType Leaf) {
@@ -155,10 +164,11 @@ function Set-ClaudeSettingsSymlink {
       $BackupRoot = Join-Path $SharedVSCodeWorktreePath '_generated\ClaudeSettingsBackups'
     }
 
-    if (-not $PSCmdlet.ShouldProcess($targetPath, 'render real Claude Code settings file from SharedVSCode overlay')) {
+    if (-not $PSCmdlet.ShouldProcess($targetPath, 'render real Claude Code settings file from SharedVSCode projection')) {
       return [PSCustomObject]@{
         TargetPath = $targetPath
-        OverlayPath = $overlayPath
+        SourceSettingsPath = $sourceSettingsPath
+        OverlayPath = $sourceSettingsPath
         BackupPath = $null
         Action = 'whatif'
         LinkType = if ($existingItem) { [string]$existingItem.LinkType } else { $null }
@@ -194,7 +204,8 @@ function Set-ClaudeSettingsSymlink {
 
       return [PSCustomObject]@{
         TargetPath = $targetPath
-        OverlayPath = $overlayPath
+        SourceSettingsPath = $sourceSettingsPath
+        OverlayPath = $sourceSettingsPath
         PreservePath = if (Test-Path -LiteralPath $preservePath -PathType Leaf) { $preservePath } else { $null }
         BackupPath = $backupPath
         Action = 'rendered'

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/AiRenderingChildModule.Tests.ps1
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/AiRenderingChildModule.Tests.ps1
@@ -54,7 +54,7 @@ Describe 'AiRendering child module contract' -Tag 'Unit' {
   It 'has stable-release NBGV metadata' {
     $metadata = Get-Content -LiteralPath (Join-Path $script:moduleRoot 'version.json') -Raw |
       ConvertFrom-Json
-    $metadata.version | Should -Be '0.1.1'
+    $metadata.version | Should -Be '0.1.2'
     @($metadata.publicReleaseRefSpec) | Should -Contain '.*'
   }
 }

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/Set-ClaudeSettingsSymlink.Tests.ps1
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/Set-ClaudeSettingsSymlink.Tests.ps1
@@ -18,14 +18,16 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
     $script:testRoot = Join-Path (
       [IO.Path]::GetTempPath()
     ) ('claude-settings-render-' + [Guid]::NewGuid().ToString('N'))
-    $script:sharedRoot = Join-Path $script:testRoot 'SharedVSCode'
+    $script:sharedRoot = Join-Path $script:testRoot 'SharedVSCode-wt-56-Sprint-0013-work-items'
+    $script:sharedStable = Join-Path $script:testRoot 'SharedVSCode'
     $script:userRoot = Join-Path $script:testRoot 'UserProfile'
     $script:configRoot = Join-Path $script:sharedRoot '.ai\config\claudecode'
-    New-Item -ItemType Directory -Path $script:configRoot -Force | Out-Null
-    $script:renderedSettingsPath = Join-Path $script:sharedRoot '.claude\settings.json'
-    New-Item -ItemType Directory -Path (Split-Path $script:renderedSettingsPath -Parent) -Force | Out-Null
+    New-Item -ItemType Directory -Path $script:configRoot, $script:sharedStable -Force | Out-Null
+    $script:overlayPath = Join-Path $script:configRoot 'settings.overlay.json'
+    $script:planningSprint = Join-Path $script:testRoot '_Planning-wt-28-Sprint-0013-work-items'
+    New-Item -ItemType Directory -Path $script:planningSprint -Force | Out-Null
     [IO.File]::WriteAllText(
-      $script:renderedSettingsPath,
+      $script:overlayPath,
       (@{
           model = 'sonnet'
           permissions = @{
@@ -33,13 +35,17 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
             allow = @('PowerShell(:*)')
             deny = @()
             ask = @()
+            additionalDirectories = @(
+              '${STABLE_WORKTREE_PATH_SHAREDVSCODE}',
+              '${SPRINT_WORKTREE_PATH_ATAP_PLANNING}'
+            )
           }
           hooks = @{
             PreToolUse = @(@{
                 matcher = 'Bash|PowerShell'
                 hooks = @(@{
                     type = 'command'
-                    command = 'pwsh -File "C:\GitHub\SharedVSCode\.claude\hooks\PreToolUse-PwshGuard.ps1"'
+                    command = 'pwsh -File "${SPRINT_WORKTREE_PATH_SHAREDVSCODE}\.claude\hooks\PreToolUse-PwshGuard.ps1"'
                   })
               })
           }
@@ -107,15 +113,17 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
     $settings.permissions.defaultMode | Should -Be 'acceptEdits'
     $settings.permissions.allow | Should -Contain 'PowerShell(:*)'
     $settings.env.CLAUDE_CODE_SHELL | Should -Be 'pwsh'
-    $settings.hooks.PreToolUse[0].hooks[0].command | Should -Match 'C:\\GitHub\\SharedVSCode'
+    $settings.permissions.additionalDirectories | Should -Contain $script:sharedStable
+    $settings.permissions.additionalDirectories | Should -Contain $script:planningSprint
+    $settings.hooks.PreToolUse[0].hooks[0].command | Should -Match ([regex]::Escape($script:sharedRoot))
     ($settings | ConvertTo-Json -Depth 20) | Should -Not -Match 'WORKTREE_PATH'
     $settings.localPreference | Should -Be 'keep-me'
   }
 
   It 'rejects a rendered projection that still contains a worktree placeholder' {
     [IO.File]::WriteAllText(
-      $script:renderedSettingsPath,
-      '{"permissions":{"additionalDirectories":["${STABLE_WORKTREE_PATH_SHAREDVSCODE}"]}}',
+      $script:overlayPath,
+      '{"permissions":{"additionalDirectories":["${STABLE_WORKTREE_PATH_UNKNOWN}"]}}',
       [Text.UTF8Encoding]::new($false)
     )
 
@@ -126,6 +134,24 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
         -CheckpointConfirmed `
         -Confirm:$false
     } | Should -Throw '*unresolved worktree placeholders*'
+  }
+
+  It 'omits sprint directories and resolves the hook to stable SharedVSCode at End' {
+    Set-ClaudeSettingsSymlink `
+      -SharedVSCodeWorktreePath $script:sharedRoot `
+      -AllowUserGlobalWrite `
+      -CheckpointConfirmed `
+      -OmitSprintWorktrees `
+      -Confirm:$false
+
+    $settingsPath = Join-Path $script:userRoot '.claude\settings.json'
+    $settingsText = Get-Content -LiteralPath $settingsPath -Raw
+    $settings = $settingsText | ConvertFrom-Json -Depth 20
+    $settings.permissions.additionalDirectories | Should -Contain $script:sharedStable
+    $settings.permissions.additionalDirectories | Should -Not -Contain $script:planningSprint
+    $settings.hooks.PreToolUse[0].hooks[0].command | Should -Match ([regex]::Escape($script:sharedStable))
+    $settingsText | Should -Not -Match 'WORKTREE_PATH'
+    $settingsText | Should -Not -Match '-wt-28-Sprint-0013-work-items'
   }
 
   It 'replaces a symlink target with a real settings file' {

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/Set-ClaudeSettingsSymlink.Tests.ps1
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/tests/Unit/Set-ClaudeSettingsSymlink.Tests.ps1
@@ -22,8 +22,10 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
     $script:userRoot = Join-Path $script:testRoot 'UserProfile'
     $script:configRoot = Join-Path $script:sharedRoot '.ai\config\claudecode'
     New-Item -ItemType Directory -Path $script:configRoot -Force | Out-Null
+    $script:renderedSettingsPath = Join-Path $script:sharedRoot '.claude\settings.json'
+    New-Item -ItemType Directory -Path (Split-Path $script:renderedSettingsPath -Parent) -Force | Out-Null
     [IO.File]::WriteAllText(
-      (Join-Path $script:configRoot 'settings.overlay.json'),
+      $script:renderedSettingsPath,
       (@{
           model = 'sonnet'
           permissions = @{
@@ -31,6 +33,15 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
             allow = @('PowerShell(:*)')
             deny = @()
             ask = @()
+          }
+          hooks = @{
+            PreToolUse = @(@{
+                matcher = 'Bash|PowerShell'
+                hooks = @(@{
+                    type = 'command'
+                    command = 'pwsh -File "C:\GitHub\SharedVSCode\.claude\hooks\PreToolUse-PwshGuard.ps1"'
+                  })
+              })
           }
           env = @{ CLAUDE_CODE_SHELL = 'pwsh' }
         } | ConvertTo-Json -Depth 10),
@@ -96,7 +107,25 @@ Describe 'Set-ClaudeSettingsSymlink managed render boundary' {
     $settings.permissions.defaultMode | Should -Be 'acceptEdits'
     $settings.permissions.allow | Should -Contain 'PowerShell(:*)'
     $settings.env.CLAUDE_CODE_SHELL | Should -Be 'pwsh'
+    $settings.hooks.PreToolUse[0].hooks[0].command | Should -Match 'C:\\GitHub\\SharedVSCode'
+    ($settings | ConvertTo-Json -Depth 20) | Should -Not -Match 'WORKTREE_PATH'
     $settings.localPreference | Should -Be 'keep-me'
+  }
+
+  It 'rejects a rendered projection that still contains a worktree placeholder' {
+    [IO.File]::WriteAllText(
+      $script:renderedSettingsPath,
+      '{"permissions":{"additionalDirectories":["${STABLE_WORKTREE_PATH_SHAREDVSCODE}"]}}',
+      [Text.UTF8Encoding]::new($false)
+    )
+
+    {
+      Set-ClaudeSettingsSymlink `
+        -SharedVSCodeWorktreePath $script:sharedRoot `
+        -AllowUserGlobalWrite `
+        -CheckpointConfirmed `
+        -Confirm:$false
+    } | Should -Throw '*unresolved worktree placeholders*'
   }
 
   It 'replaces a symlink target with a real settings file' {

--- a/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/version.json
+++ b/src/ATAP.Utilities.BuildTooling.AiRendering.PowerShell/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "nuGetPackageVersion": {
     "semVer": 2
   },

--- a/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/ReleaseNotes.md
+++ b/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/ReleaseNotes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.1.27
+
+- Classify committed `SolutionDocumentation/*-Task-N.before.summary.json` and
+  `*.after.summary.json` files as historical SprintEnd evidence rather than
+  live configuration drift.
+
 ## 0.1.26
 
 - Forward the verified checkpoint and user-global write gates from the typed

--- a/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/public/Test-SprintEndBoundaryState.ps1
+++ b/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/public/Test-SprintEndBoundaryState.ps1
@@ -145,12 +145,16 @@ function Test-SprintEndBoundaryState {
     $extensions = @('*.code-workspace', '*.json', '*.jsonc', '*.toml')
     $alwaysSkipPathPattern = '[\\/]\.git[\\/]'
     $historicalEvidencePathPattern = '(?i)[\\/](?:_generated|SprintHistory|SprintRetrospective|Archived|Samples?)[\\/]'
+    $committedTaskEvidencePathPattern = '(?i)[\\/]SolutionDocumentation[\\/][^\\/]*-Task-\d+(?:\.\d+)*\.(?:before|after)\.summary\.json$'
     foreach ($searchRoot in $SearchRoots) {
       if (-not (Test-Path -LiteralPath $searchRoot -PathType Container)) { continue }
       foreach ($extension in $extensions) {
         foreach ($file in @(Get-ChildItem -LiteralPath $searchRoot -Filter $extension -File -Recurse -ErrorAction SilentlyContinue)) {
           if ($file.FullName -match $alwaysSkipPathPattern) { continue }
-          $classification = if ($file.FullName -match $historicalEvidencePathPattern) {
+          $classification = if (
+            $file.FullName -match $historicalEvidencePathPattern -or
+            $file.FullName -match $committedTaskEvidencePathPattern
+          ) {
             'HistoricalEvidence'
           } else {
             'LiveConfiguration'

--- a/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/tests/Unit/Test-SprintEndBoundaryState.Tests.ps1
+++ b/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/tests/Unit/Test-SprintEndBoundaryState.Tests.ps1
@@ -79,6 +79,28 @@ Describe 'Test-SprintEndBoundaryState stale-reference scope split' -Tag 'Unit' {
       $result.HistoricalStaleReferences.Count | Should -Be $folders.Count
     }
 
+    It 'classifies committed Task before and after summary JSON as historical evidence' {
+      $gitRoot = Join-Path $TestDrive 'committed-task-evidence'
+      $documentationRoot = Join-Path $gitRoot 'SharedVSCode\SolutionDocumentation'
+      New-Item -ItemType Directory -Path $documentationRoot -Force | Out-Null
+      foreach ($phase in @('before', 'after')) {
+        Set-Content -LiteralPath (Join-Path $documentationRoot "AI-Instruction-Inventory-Task-8.20.$phase.summary.json") `
+          -Value '{"path":"SharedVSCode-wt-44-Sprint-0008-work-items"}'
+      }
+
+      $result = Test-SprintEndBoundaryState `
+        -GitRoot $gitRoot `
+        -SearchRoots @($gitRoot) `
+        -ProfilePaths @() `
+        -ProhibitedEnvironmentVariableNames @()
+
+      $result.Ok | Should -BeTrue
+      $result.LiveStaleReferences.Count | Should -Be 0
+      $result.HistoricalStaleReferences.Count | Should -Be 2
+      @($result.HistoricalStaleReferences | Select-Object -ExpandProperty Classification -Unique) |
+        Should -Be @('HistoricalEvidence')
+    }
+
     It 'fails with only the live finding as the cause when both live and historical stale paths exist' {
       $gitRoot = Join-Path $TestDrive 'mixed'
       $historyDir = Join-Path $gitRoot 'SprintHistory'

--- a/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/version.json
+++ b/src/ATAP.Utilities.BuildTooling.SprintLifecycle.PowerShell/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "nuGetPackageVersion": {
     "semVer": 2
   },


### PR DESCRIPTION
## Summary
- resolve the full Claude user overlay against stable worktree roots
- omit sprint-only entries at the End boundary and reject unresolved tokens
- classify committed task inventory summaries as historical evidence
- bump AiRendering to 0.1.2 and SprintLifecycle to 0.1.27

## Verification
- AiRendering unit suite: 32 passed
- Claude settings focused suite: 7 passed
- Set-SprintBoundaryContext: 37 passed
- Invoke-SprintAIAdapterLifecycle: 8 passed
- Test-SprintEndBoundaryState: 6 passed

Closes #128